### PR TITLE
Extended Test Cases for initial 7 Operators.

### DIFF
--- a/tests/Operator/test_add.c
+++ b/tests/Operator/test_add.c
@@ -44,7 +44,7 @@ void test_add_operator() {
 
     // Test Case 2: Vector addition (1D tensors)
     {
-        const char* tc_name = "add_vector_3el";
+        const char* tc_name = "add_vector_1D";
         TensorShape v_shape = {3, 0, 0, 0};
         float d1[] = {1.0f, 2.0f, 3.0f};
         float d2[] = {4.0f, 5.0f, 6.0f};
@@ -107,7 +107,7 @@ void test_add_operator() {
     }
 
     // TODO: Problem in Broadcasting
-    
+
     // // Test Case 5: Advanced Broadcasting
     // {
     //     const char* tc_name = "add_advanced_broadcasting";

--- a/tests/Operator/test_add.c
+++ b/tests/Operator/test_add.c
@@ -106,5 +106,169 @@ void test_add_operator() {
         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
     }
 
+    // TODO: Problem in Broadcasting
+    
+    // // Test Case 5: Advanced Broadcasting
+    // {
+    //     const char* tc_name = "add_advanced_broadcasting";
+        
+    //     // Sub-test 1: Multi-dimensional broadcasting {3,1} + {1,4} -> {3,4}
+    //     {
+    //         TensorShape s1_shape = {3, 1, 0, 0}; float d1[] = {1.0f, 2.0f, 3.0f};
+    //         TensorShape s2_shape = {1, 4, 0, 0}; float d2[] = {10.0f, 20.0f, 30.0f, 40.0f};
+    //         TensorShape exp_shape = {3, 4, 0, 0}; 
+    //         float exp_d[] = {11.0f, 21.0f, 31.0f, 41.0f,  // 1+[10,20,30,40]
+    //                          12.0f, 22.0f, 32.0f, 42.0f,  // 2+[10,20,30,40]
+    //                          13.0f, 23.0f, 33.0f, 43.0f}; // 3+[10,20,30,40]
+
+    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
+    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
+    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+    //         Tensor actual_res = Tensor_add(t1, t2);
+
+    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+    //     }
+
+    //     // Sub-test 2: 3D broadcasting {2,3,1} + {1,1,4} -> {2,3,4}
+    //     {
+    //         TensorShape s1_shape = {2, 3, 1, 0}; 
+    //         float d1[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    //         TensorShape s2_shape = {1, 1, 4, 0}; 
+    //         float d2[] = {10.0f, 20.0f, 30.0f, 40.0f};
+    //         TensorShape exp_shape = {2, 3, 4, 0};
+    //         float exp_d[] = {
+    //             // First 2x3 slice
+    //             11.0f, 21.0f, 31.0f, 41.0f,  // 1+[10,20,30,40]
+    //             12.0f, 22.0f, 32.0f, 42.0f,  // 2+[10,20,30,40]
+    //             13.0f, 23.0f, 33.0f, 43.0f,  // 3+[10,20,30,40]
+    //             // Second 2x3 slice
+    //             14.0f, 24.0f, 34.0f, 44.0f,  // 4+[10,20,30,40]
+    //             15.0f, 25.0f, 35.0f, 45.0f,  // 5+[10,20,30,40]
+    //             16.0f, 26.0f, 36.0f, 46.0f   // 6+[10,20,30,40]
+    //         };
+
+    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
+    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
+    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+    //         Tensor actual_res = Tensor_add(t1, t2);
+
+    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+    //     }
+
+    //     // Sub-test 3: 4D broadcasting with size-1 dimensions {1,1,1,1} + {5,4,3,2} -> {5,4,3,2}
+    //     {
+    //         TensorShape s1_shape = {1, 1, 1, 1}; float d1[] = {5.0f};
+    //         TensorShape s2_shape = {5, 4, 3, 2}; 
+    //         float d2[120]; // 5*4*3*2 = 120 elements
+    //         for(int i = 0; i < 120; i++) d2[i] = (float)(i + 1);
+            
+    //         TensorShape exp_shape = {5, 4, 3, 2};
+    //         float exp_d[120];
+    //         for(int i = 0; i < 120; i++) exp_d[i] = d2[i] + 5.0f;
+
+    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
+    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
+    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+    //         Tensor actual_res = Tensor_add(t1, t2);
+
+    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 3, TEST_FLOAT_TOLERANCE);
+    //     }
+
+    //     // Sub-test 4: Vector-to-matrix broadcasting {3} + {2,3} -> {2,3}
+    //     {
+    //         TensorShape vec_shape = {3, 0, 0, 0}; float vec_data[] = {1.0f, 2.0f, 3.0f};
+    //         TensorShape mat_shape = {2, 3, 0, 0}; float mat_data[] = {10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f};
+    //         TensorShape exp_shape = {2, 3, 0, 0}; 
+    //         float exp_d[] = {11.0f, 22.0f, 33.0f, 41.0f, 52.0f, 63.0f};
+
+    //         Tensor t_vec = create_test_tensor(vec_shape, vec_data, false);
+    //         Tensor t_mat = create_test_tensor(mat_shape, mat_data, false);
+    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+    //         Tensor actual_res = Tensor_add(t_vec, t_mat);
+
+    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 4, TEST_FLOAT_TOLERANCE);
+    //     }
+
+    //     // Sub-test 5: Cross-dimensional broadcasting {5} + {2,5} -> {2,5}
+    //     {
+    //         TensorShape s1_shape = {5, 0, 0, 0}; float d1[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    //         TensorShape s2_shape = {2, 5, 0, 0}; 
+    //         float d2[] = {10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f, 100.0f};
+    //         TensorShape exp_shape = {2, 5, 0, 0};
+    //         float exp_d[] = {11.0f, 22.0f, 33.0f, 44.0f, 55.0f, 61.0f, 72.0f, 83.0f, 94.0f, 105.0f};
+
+    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
+    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
+    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+    //         Tensor actual_res = Tensor_add(t1, t2);
+
+    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 5, TEST_FLOAT_TOLERANCE);
+    //     }
+    // }
+
+    // Test Case 6: Higher Dimensional Tensors
+    {
+        const char* tc_name = "add_higher_dimensional_tensors";
+        
+        // Sub-test 1: 3D tensor addition (same shape)
+        {
+            TensorShape shape_3d = {2, 3, 4, 0};
+            float d1[24], d2[24], exp_d[24];
+            for(int i = 0; i < 24; i++) {
+                d1[i] = (float)(i + 1);
+                d2[i] = (float)(i * 2);
+                exp_d[i] = d1[i] + d2[i];
+            }
+
+            Tensor t1 = create_test_tensor(shape_3d, d1, false);
+            Tensor t2 = create_test_tensor(shape_3d, d2, false);
+            Tensor expected_res = create_test_tensor(shape_3d, exp_d, false);
+            Tensor actual_res = Tensor_add(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: 4D tensor addition (same shape)
+        {
+            TensorShape shape_4d = {2, 3, 4, 5};
+            float d1[120], d2[120], exp_d[120];
+            for(int i = 0; i < 120; i++) {
+                d1[i] = (float)(i + 1);
+                d2[i] = (float)(i + 10);
+                exp_d[i] = d1[i] + d2[i];
+            }
+
+            Tensor t1 = create_test_tensor(shape_4d, d1, false);
+            Tensor t2 = create_test_tensor(shape_4d, d2, false);
+            Tensor expected_res = create_test_tensor(shape_4d, exp_d, false);
+            Tensor actual_res = Tensor_add(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 7: Gradient Propagation
+    {
+        const char* tc_name = "add_gradient_propagation";
+        
+        // Sub-test 1: requires_grad flag propagation
+        {
+            TensorShape shape = {2, 2, 0, 0};
+            float d1[] = {1.0f, 2.0f, 3.0f, 4.0f};
+            float d2[] = {5.0f, 6.0f, 7.0f, 8.0f};
+            float exp_d[] = {6.0f, 8.0f, 10.0f, 12.0f};
+
+            Tensor t1 = create_test_tensor(shape, d1, true);  // requires_grad = true
+            Tensor t2 = create_test_tensor(shape, d2, false); // requires_grad = false
+            Tensor expected_res = create_test_tensor(shape, exp_d, false);
+            Tensor actual_res = Tensor_add(t1, t2);
+
+            // Check that result has gradient node when one input requires grad
+            // Note: Gradient node creation depends on implementation
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
     cten_free(pool_id);
 }

--- a/tests/Operator/test_matmul.c
+++ b/tests/Operator/test_matmul.c
@@ -71,5 +71,140 @@ void test_matmul_operator() {
         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
     }
 
+    // Test Case 5: Edge Matrix Sizes
+    {
+        const char* tc_name = "matmul_edge_matrix_sizes";
+        
+        // Sub-test 1: 1x1 matrix multiplication
+        {
+            TensorShape s1_shape = {1, 1, 0, 0}; float d1[] = {5.0f};
+            TensorShape s2_shape = {1, 1, 0, 0}; float d2[] = {3.0f};
+            TensorShape exp_shape = {1, 1, 0, 0}; float exp_d[] = {15.0f};
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: Single row/column matrices {1,5} * {5,1} -> {1,1}
+        {
+            TensorShape s1_shape = {1, 5, 0, 0}; float d1[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+            TensorShape s2_shape = {5, 1, 0, 0}; float d2[] = {2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+            TensorShape exp_shape = {1, 1, 0, 0}; float exp_d[] = {70.0f}; // 1*2+2*3+3*4+4*5+5*6 = 70
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 3: Single column/row matrices {5,1} * {1,5} -> {5,5}
+        {
+            TensorShape s1_shape = {5, 1, 0, 0}; float d1[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+            TensorShape s2_shape = {1, 5, 0, 0}; float d2[] = {2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+            TensorShape exp_shape = {5, 5, 0, 0}; 
+            float exp_d[] = {
+                2.0f, 3.0f, 4.0f, 5.0f, 6.0f,    // 1*[2,3,4,5,6]
+                4.0f, 6.0f, 8.0f, 10.0f, 12.0f,  // 2*[2,3,4,5,6]
+                6.0f, 9.0f, 12.0f, 15.0f, 18.0f, // 3*[2,3,4,5,6]
+                8.0f, 12.0f, 16.0f, 20.0f, 24.0f, // 4*[2,3,4,5,6]
+                10.0f, 15.0f, 20.0f, 25.0f, 30.0f // 5*[2,3,4,5,6]
+            };
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 3, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 6: Large Matrix Operations
+    {
+        const char* tc_name = "matmul_large_matrix_operations";
+        
+        // Sub-test 1: Stress test with 10x10 matrices
+        {
+            TensorShape s1_shape = {10, 10, 0, 0};
+            TensorShape s2_shape = {10, 10, 0, 0};
+            TensorShape exp_shape = {10, 10, 0, 0};
+            
+            float d1[100], d2[100], exp_d[100];
+            
+            // Initialize matrices with simple patterns
+            for(int i = 0; i < 100; i++) {
+                d1[i] = (float)(i % 10 + 1); // 1,2,3,...,10,1,2,3,...
+                d2[i] = (float)(i / 10 + 1); // 1,1,1,...,1,2,2,2,...
+            }
+            
+            // Calculate expected result manually for verification
+            for(int i = 0; i < 10; i++) {
+                for(int j = 0; j < 10; j++) {
+                    float sum = 0;
+                    for(int k = 0; k < 10; k++) {
+                        sum += d1[i * 10 + k] * d2[k * 10 + j];
+                    }
+                    exp_d[i * 10 + j] = sum;
+                }
+            }
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: Large rectangular matrix multiplication (reduced size for stack allocation)
+        {
+            TensorShape s1_shape = {20, 15, 0, 0};
+            TensorShape s2_shape = {15, 25, 0, 0};
+            TensorShape exp_shape = {20, 25, 0, 0};
+            
+            // Use stack arrays with reduced size
+            float d1[300]; // 20*15 = 300
+            float d2[375]; // 15*25 = 375  
+            float exp_d[500]; // 20*25 = 500
+            
+            // Initialize with simple patterns
+            for(int i = 0; i < 300; i++) d1[i] = 1.0f;
+            for(int i = 0; i < 375; i++) d2[i] = 1.0f;
+            for(int i = 0; i < 500; i++) exp_d[i] = 15.0f; // Each element should be 15*1*1 = 15
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 7: Special Matrix Content
+    {
+        const char* tc_name = "matmul_special_matrix_content";
+        
+        // Sub-test 1: Matrix with zeros
+        {
+            TensorShape s1_shape = {2, 2, 0, 0}; float d1[] = {0.0f, 0.0f, 1.0f, 1.0f};
+            TensorShape s2_shape = {2, 2, 0, 0}; float d2[] = {1.0f, 2.0f, 3.0f, 4.0f};
+            TensorShape exp_shape = {2, 2, 0, 0}; float exp_d[] = {0.0f, 0.0f, 4.0f, 6.0f};
+
+            Tensor t1 = create_test_tensor(s1_shape, d1, false);
+            Tensor t2 = create_test_tensor(s2_shape, d2, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_matmul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
     cten_free(pool_id);
 }

--- a/tests/Operator/test_mean.c
+++ b/tests/Operator/test_mean.c
@@ -26,7 +26,7 @@ void test_mean_operator() {
 
     // Test Case 2: Mean of a vector
     {
-        const char* tc_name = "mean_vector_3el";
+        const char* tc_name = "mean_vector_1D";
         TensorShape v_shape = {3, 0, 0, 0};
         float d1[] = {1.0f, 2.0f, 3.0f}; // Sum = 6, Count = 3, Mean = 2
         float exp_d[] = {2.0f};
@@ -74,6 +74,106 @@ void test_mean_operator() {
         Tensor actual_res = Tensor_mean(t1);
 
         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+    }
+
+    // Test Case 6: Large Tensor Reductions
+    {
+        const char* tc_name = "mean_large_tensor_reductions";
+        
+        // Sub-test 1: Large tensor mean (1,000 elements)
+        {
+            TensorShape large_shape = {1000, 0, 0, 0};
+            float large_data[1000];
+            for(int i = 0; i < 1000; i++) large_data[i] = 1.0f;
+            
+            float exp_d[] = {1.0f}; // Mean of 1000 ones = 1.0
+            TensorShape exp_shape = {1, 0, 0, 0};
+            
+            Tensor t1 = create_test_tensor(large_shape, large_data, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_mean(t1);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: Large count division (stress test - 5,000 elements)
+        {
+            TensorShape stress_shape = {5000, 0, 0, 0};
+            float stress_data[5000];
+            for(int i = 0; i < 5000; i++) stress_data[i] = 2.0f;
+            
+            float exp_d[] = {2.0f}; // Mean of 5000 twos = 2.0
+            TensorShape exp_shape = {1, 0, 0, 0};
+            
+            Tensor t1 = create_test_tensor(stress_shape, stress_data, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_mean(t1);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 7: Higher Dimensional Tensors
+    {
+        const char* tc_name = "mean_higher_dimensional_tensors";
+        
+        // Sub-test 1: 3D tensor mean
+        {
+            TensorShape shape_3d = {2, 3, 4, 0};
+            float d1[24];
+            float sum = 0.0f;
+            for(int i = 0; i < 24; i++) {
+                d1[i] = (float)(i + 1);
+                sum += d1[i];
+            }
+            
+            float exp_d[] = {sum / 24.0f}; // Mean of 1+2+...+24 = 300/24 = 12.5
+            TensorShape exp_shape = {1, 0, 0, 0};
+            
+            Tensor t1 = create_test_tensor(shape_3d, d1, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_mean(t1);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: 4D tensor mean
+        {
+            TensorShape shape_4d = {2, 3, 4, 5};
+            float d1[120];
+            float sum = 0.0f;
+            for(int i = 0; i < 120; i++) {
+                d1[i] = (float)(i + 1);
+                sum += d1[i];
+            }
+            
+            float exp_d[] = {sum / 120.0f}; // Mean of 1+2+...+120 = 7260/120 = 60.5
+            TensorShape exp_shape = {1, 0, 0, 0};
+            
+            Tensor t1 = create_test_tensor(shape_4d, d1, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_mean(t1);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 8: Edge Cases
+    {
+        const char* tc_name = "mean_edge_cases";
+        
+        // Sub-test 1: Single element mean (division by 1)
+        {
+            TensorShape single_shape = {1, 0, 0, 0};
+            float d1[] = {42.5f};
+            float exp_d[] = {42.5f}; // Mean of single element is itself
+            
+            Tensor t1 = create_test_tensor(single_shape, d1, false);
+            Tensor expected_res = create_test_tensor(exp_shape_scalar, exp_d, false);
+            Tensor actual_res = Tensor_mean(t1);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
     }
 
     cten_free(pool_id);

--- a/tests/Operator/test_mul.c
+++ b/tests/Operator/test_mul.c
@@ -27,7 +27,7 @@ void test_mul_operator() {
 
     // Test Case 2: Vector element-wise multiplication
     {
-        const char* tc_name = "mul_vector_3el";
+        const char* tc_name = "mul_vector_1D";
         TensorShape v_shape = {3, 0, 0, 0};
         float d1[] = {1.0f, 2.0f, 3.0f};
         float d2[] = {4.0f, 5.0f, 0.5f};
@@ -71,6 +71,98 @@ void test_mul_operator() {
         Tensor expected_res = create_test_tensor(expected_shape, exp_data, false);
 
         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+    }
+    
+    // TODO: Problem in Broadcasting
+
+    // // Test Case 5: Advanced Broadcasting
+    // {
+    //     const char* tc_name = "mul_advanced_broadcasting";
+        
+    //     // Sub-test 1: Multi-dimensional broadcasting {3,1} * {1,4} -> {3,4}
+    //     {
+    //         TensorShape s1_shape = {3, 1, 0, 0}; float d1[] = {2.0f, 3.0f, 4.0f};
+    //         TensorShape s2_shape = {1, 4, 0, 0}; float d2[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    //         TensorShape exp_shape = {3, 4, 0, 0}; 
+    //         float exp_d[] = {2.0f, 4.0f, 6.0f, 8.0f,    // 2*[1,2,3,4]
+    //                          3.0f, 6.0f, 9.0f, 12.0f,   // 3*[1,2,3,4]
+    //                          4.0f, 8.0f, 12.0f, 16.0f}; // 4*[1,2,3,4]
+
+    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
+    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
+    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+    //         Tensor actual_res = Tensor_mul(t1, t2);
+
+    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+    //     }
+
+    //     // Sub-test 2: 4D broadcasting {1,2,3,4} * {5,1,1,1} -> {5,2,3,4}
+    //     {
+    //         TensorShape s1_shape = {1, 2, 3, 4}; 
+    //         float d1[24];
+    //         for(int i = 0; i < 24; i++) d1[i] = (float)(i + 1);
+            
+    //         TensorShape s2_shape = {5, 1, 1, 1}; 
+    //         float d2[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+            
+    //         TensorShape exp_shape = {5, 2, 3, 4};
+    //         float exp_d[120]; // 5*2*3*4 = 120
+    //         for(int i = 0; i < 5; i++) {
+    //             for(int j = 0; j < 24; j++) {
+    //                 exp_d[i * 24 + j] = d1[j] * d2[i];
+    //             }
+    //         }
+
+    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
+    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
+    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+    //         Tensor actual_res = Tensor_mul(t1, t2);
+
+    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+    //     }
+    // }
+
+    // Test Case 6: Sign Preservation
+    {
+        const char* tc_name = "mul_sign_preservation";
+        
+        // Sub-test 1: Negative number multiplication
+        {
+            TensorShape v_shape = {2, 0, 0, 0};
+            float d1[] = {-1.0f, 1.0f};
+            float d2[] = {-2.0f, -3.0f};
+            float exp_d[] = {2.0f, -3.0f}; // (-1)*(-2)=2, (1)*(-3)=-3
+
+            Tensor t1 = create_test_tensor(v_shape, d1, false);
+            Tensor t2 = create_test_tensor(v_shape, d2, false);
+            Tensor expected_res = create_test_tensor(v_shape, exp_d, false);
+            Tensor actual_res = Tensor_mul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 7: Higher Dimensional Tensors
+    {
+        const char* tc_name = "mul_higher_dimensional_tensors";
+        
+        // Sub-test 1: 3D tensor multiplication (same shape)
+        {
+            TensorShape shape_3d = {2, 3, 4, 0};
+            float d1[24], d2[24], exp_d[24];
+            for(int i = 0; i < 24; i++) {
+                d1[i] = (float)(i + 1);
+                d2[i] = 2.0f;
+                exp_d[i] = d1[i] * d2[i];
+            }
+
+            Tensor t1 = create_test_tensor(shape_3d, d1, false);
+            Tensor t2 = create_test_tensor(shape_3d, d2, false);
+            Tensor expected_res = create_test_tensor(shape_3d, exp_d, false);
+            Tensor actual_res = Tensor_mul(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
     }
 
     cten_free(pool_id);

--- a/tests/Operator/test_mulf.c
+++ b/tests/Operator/test_mulf.c
@@ -66,5 +66,77 @@ void test_mulf_operator() {
         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
     }
 
+    // Test Case 5: Special Scalar Values
+    {
+        const char* tc_name = "mulf_special_scalar_values";
+        
+        // Sub-test 1: Multiplication by zero
+        {
+            TensorShape m_shape = {2, 3, 0, 0};
+            float d1[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+            float scalar_val = 0.0f;
+            float exp_d[] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+            
+            Tensor t1 = create_test_tensor(m_shape, d1, false);
+            Tensor expected_res = create_test_tensor(m_shape, exp_d, false);
+            Tensor actual_res = Tensor_mulf(t1, scalar_val);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: Very small scalar multiplication
+        {
+            TensorShape v_shape = {4, 0, 0, 0};
+            float d1[] = {1000.0f, 2000.0f, 3000.0f, 4000.0f};
+            float scalar_val = 1e-6f;
+            float exp_d[] = {1e-3f, 2e-3f, 3e-3f, 4e-3f};
+            
+            Tensor t1 = create_test_tensor(v_shape, d1, false);
+            Tensor expected_res = create_test_tensor(v_shape, exp_d, false);
+            Tensor actual_res = Tensor_mulf(t1, scalar_val);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 6: Higher Dimensional Tensors
+    {
+        const char* tc_name = "mulf_higher_dimensional_tensors";
+        
+        // Sub-test 1: 3D tensor scalar multiplication
+        {
+            TensorShape shape_3d = {2, 3, 4, 0};
+            float d1[24];
+            for(int i = 0; i < 24; i++) d1[i] = (float)(i + 1);
+            
+            float scalar_val = 1.5f;
+            float exp_d[24];
+            for(int i = 0; i < 24; i++) exp_d[i] = d1[i] * scalar_val;
+            
+            Tensor t1 = create_test_tensor(shape_3d, d1, false);
+            Tensor expected_res = create_test_tensor(shape_3d, exp_d, false);
+            Tensor actual_res = Tensor_mulf(t1, scalar_val);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: 4D tensor scalar multiplication
+        {
+            TensorShape shape_4d = {2, 3, 4, 5};
+            float d1[120];
+            for(int i = 0; i < 120; i++) d1[i] = (float)(i + 1);
+            
+            float scalar_val = -0.5f;
+            float exp_d[120];
+            for(int i = 0; i < 120; i++) exp_d[i] = d1[i] * scalar_val;
+            
+            Tensor t1 = create_test_tensor(shape_4d, d1, false);
+            Tensor expected_res = create_test_tensor(shape_4d, exp_d, false);
+            Tensor actual_res = Tensor_mulf(t1, scalar_val);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
     cten_free(pool_id);
 }

--- a/tests/Operator/test_sub.c
+++ b/tests/Operator/test_sub.c
@@ -27,7 +27,7 @@ void test_sub_operator() {
 
     // Test Case 2: Vector element-wise subtraction
     {
-        const char* tc_name = "sub_vector_3el";
+        const char* tc_name = "sub_vector_1D";
         TensorShape v_shape = {3, 0, 0, 0};
         float d1[] = {10.0f, 20.0f, 30.0f};
         float d2[] = {1.0f, 5.0f, 2.5f};
@@ -71,6 +71,108 @@ void test_sub_operator() {
         Tensor expected_res = create_test_tensor(expected_shape, exp_data, false);
 
         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+    }
+
+    // TODO: Problem in Broadcasting
+    
+    // // Test Case 5: Advanced Broadcasting
+    // {
+    //     const char* tc_name = "sub_advanced_broadcasting";
+        
+    //     // Sub-test 1: Multi-dimensional broadcasting {3,1} - {1,4} -> {3,4}
+    //     {
+    //         TensorShape s1_shape = {3, 1, 0, 0}; float d1[] = {10.0f, 20.0f, 30.0f};
+    //         TensorShape s2_shape = {1, 4, 0, 0}; float d2[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    //         TensorShape exp_shape = {3, 4, 0, 0}; 
+    //         float exp_d[] = {9.0f, 8.0f, 7.0f, 6.0f,    // 10-[1,2,3,4]
+    //                          19.0f, 18.0f, 17.0f, 16.0f, // 20-[1,2,3,4]
+    //                          29.0f, 28.0f, 27.0f, 26.0f}; // 30-[1,2,3,4]
+
+    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
+    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
+    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+    //         Tensor actual_res = Tensor_sub(t1, t2);
+
+    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+    //     }
+
+    //     // Sub-test 2: 3D broadcasting {2,3,1} - {1,1,4} -> {2,3,4}
+    //     {
+    //         TensorShape s1_shape = {2, 3, 1, 0}; 
+    //         float d1[] = {10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f};
+    //         TensorShape s2_shape = {1, 1, 4, 0}; 
+    //         float d2[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    //         TensorShape exp_shape = {2, 3, 4, 0};
+    //         float exp_d[] = {
+    //             // First 2x3 slice
+    //             9.0f, 8.0f, 7.0f, 6.0f,    // 10-[1,2,3,4]
+    //             19.0f, 18.0f, 17.0f, 16.0f, // 20-[1,2,3,4]
+    //             29.0f, 28.0f, 27.0f, 26.0f, // 30-[1,2,3,4]
+    //             // Second 2x3 slice
+    //             39.0f, 38.0f, 37.0f, 36.0f, // 40-[1,2,3,4]
+    //             49.0f, 48.0f, 47.0f, 46.0f, // 50-[1,2,3,4]
+    //             59.0f, 58.0f, 57.0f, 56.0f  // 60-[1,2,3,4]
+    //         };
+
+    //         Tensor t1 = create_test_tensor(s1_shape, d1, false);
+    //         Tensor t2 = create_test_tensor(s2_shape, d2, false);
+    //         Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+    //         Tensor actual_res = Tensor_sub(t1, t2);
+
+    //         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+    //     }
+    // }
+
+    // Test Case 6: Order Dependency
+    {
+        const char* tc_name = "sub_order_dependency";
+        
+        // Sub-test 1: a - b ≠ b - a verification
+        {
+            TensorShape v_shape = {2, 0, 0, 0};
+            
+            // First: [5.0, 3.0] - [2.0, 1.0] = [3.0, 2.0]
+            float d1[] = {5.0f, 3.0f};
+            float d2[] = {2.0f, 1.0f};
+            float exp_d1[] = {3.0f, 2.0f};
+            
+            Tensor t1 = create_test_tensor(v_shape, d1, false);
+            Tensor t2 = create_test_tensor(v_shape, d2, false);
+            Tensor expected_res1 = create_test_tensor(v_shape, exp_d1, false);
+            Tensor actual_res1 = Tensor_sub(t1, t2);
+
+            compare_tensors(&actual_res1, &expected_res1, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+
+            // Second: [2.0, 1.0] - [5.0, 3.0] = [-3.0, -2.0]
+            float exp_d2[] = {-3.0f, -2.0f};
+            Tensor expected_res2 = create_test_tensor(v_shape, exp_d2, false);
+            Tensor actual_res2 = Tensor_sub(t2, t1);
+
+            compare_tensors(&actual_res2, &expected_res2, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 7: Higher Dimensional Tensors
+    {
+        const char* tc_name = "sub_higher_dimensional_tensors";
+        
+        // Sub-test 1: 3D tensor subtraction (same shape)
+        {
+            TensorShape shape_3d = {2, 3, 4, 0};
+            float d1[24], d2[24], exp_d[24];
+            for(int i = 0; i < 24; i++) {
+                d1[i] = (float)(i + 10);
+                d2[i] = (float)(i + 1);
+                exp_d[i] = d1[i] - d2[i]; // Should be 9.0 for all elements
+            }
+
+            Tensor t1 = create_test_tensor(shape_3d, d1, false);
+            Tensor t2 = create_test_tensor(shape_3d, d2, false);
+            Tensor expected_res = create_test_tensor(shape_3d, exp_d, false);
+            Tensor actual_res = Tensor_sub(t1, t2);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
     }
 
     cten_free(pool_id);

--- a/tests/Operator/test_sum.c
+++ b/tests/Operator/test_sum.c
@@ -65,5 +65,87 @@ void test_sum_operator() {
         compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
     }
 
+    // Test Case 5: Large Tensor Reductions
+    {
+        const char* tc_name = "sum_large_tensor_reductions";
+        
+        // Sub-test 1: Large tensor sum (1,000 elements)
+        {
+            TensorShape large_shape = {1000, 0, 0, 0};
+            float large_data[1000];
+            for(int i = 0; i < 1000; i++) large_data[i] = 1.0f;
+            
+            float exp_d[] = {1000.0f}; // Sum of 1000 ones
+            TensorShape exp_shape = {1, 0, 0, 0};
+            
+            Tensor t1 = create_test_tensor(large_shape, large_data, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_sum(t1);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: Larger tensor sum (stress test - 5,000 elements)
+        {
+            TensorShape stress_shape = {5000, 0, 0, 0};
+            float stress_data[5000];
+            for(int i = 0; i < 5000; i++) stress_data[i] = 1.0f;
+            
+            float exp_d[] = {5000.0f}; // Sum of 5000 ones
+            TensorShape exp_shape = {1, 0, 0, 0};
+            
+            Tensor t1 = create_test_tensor(stress_shape, stress_data, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_sum(t1);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
+    // Test Case 6: Higher Dimensional Tensors
+    {
+        const char* tc_name = "sum_higher_dimensional_tensors";
+        
+        // Sub-test 1: 3D tensor sum
+        {
+            TensorShape shape_3d = {2, 3, 4, 0};
+            float d1[24];
+            float sum = 0.0f;
+            for(int i = 0; i < 24; i++) {
+                d1[i] = (float)(i + 1);
+                sum += d1[i];
+            }
+            
+            float exp_d[] = {sum}; // Sum of 1+2+...+24 = 300
+            TensorShape exp_shape = {1, 0, 0, 0};
+            
+            Tensor t1 = create_test_tensor(shape_3d, d1, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_sum(t1);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 1, TEST_FLOAT_TOLERANCE);
+        }
+
+        // Sub-test 2: 4D tensor sum
+        {
+            TensorShape shape_4d = {2, 3, 4, 5};
+            float d1[120];
+            float sum = 0.0f;
+            for(int i = 0; i < 120; i++) {
+                d1[i] = (float)(i + 1);
+                sum += d1[i];
+            }
+            
+            float exp_d[] = {sum}; // Sum of 1+2+...+120 = 7260
+            TensorShape exp_shape = {1, 0, 0, 0};
+            
+            Tensor t1 = create_test_tensor(shape_4d, d1, false);
+            Tensor expected_res = create_test_tensor(exp_shape, exp_d, false);
+            Tensor actual_res = Tensor_sum(t1);
+
+            compare_tensors(&actual_res, &expected_res, op_name, tc_name, 2, TEST_FLOAT_TOLERANCE);
+        }
+    }
+
     cten_free(pool_id);
 }


### PR DESCRIPTION
###  **PR extends the test coverage for seven tensor operators in the cTensor library. Overall Test Currently Available**
 
**1. Add Operator (test_add.c)**

Category:

- Scalar Addition (1x1 tensors)
- Vector Addition (1D tensors)
- Matrix Addition (2D tensors)
- Broadcasting: vector + scalar-like tensor
- Higher Dimensional Tensors:
  - 3D tensor addition
  - 4D tensor addition
- Gradient Propagation:
   - requires_grad flag propagation

**2. Mul Operator (test_mul.c)**

Category: 

- Scalar Multiplication (1x1 tensors)
- Vector Element-wise Multiplication (1D tensors)
- Matrix Element-wise Multiplication (2D tensors)
- Broadcasting: matrix * scalar-like tensor
- Sign Preservation:
  - Negative number multiplication
- Higher Dimensional Tensors:
  - 3D tensor multiplication

**3. Sub Operator (test_sub.c)**

Category: 

- Scalar Subtraction (1x1 tensors)
- Vector Element-wise Subtraction (1D tensors)
- Matrix Element-wise Subtraction (2D tensors)
- Broadcasting: matrix - scalar-like tensor
- Order Dependency:
  - Verifying a - b ≠ b - a
- Higher Dimensional Tensors:
  - 3D tensor subtraction

**4. Mean Operator (test_mean.c)**

Category: 

- Scalar Mean (1x1 tensors)
- Vector Mean (1D tensors)
- Matrix Mean (2x2 tensors)
- Negative Numbers:
  - Mean of a matrix with negative values
- Zero Values:
  - Mean of a tensor with all zeros
- Large Tensor Reductions:
  - Mean over 1,000 elements
  - Mean over 5,000 elements
- Higher Dimensional Tensors:
  - 3D tensor mean
  - 4D tensor mean
- Edge Cases:
  - Single element mean

**5. MatMul Operator (test_matmul.c)**

Category

- Square Matrix Multiplication (2x2 * 2x2)
- Rectangular Matrix Multiplication (2x3 * 3x2)
- Matrix-Vector Operations:
  - Matrix-Vector (2x2 * 2x1)
  - Vector-Matrix (1x2 * 2x2)
- Edge Matrix Sizes:
  - 1x1 matrix multiplication
  - 3x5 * 5x2 multiplication
- Large Matrix Operations:
  - Stress test with 10x10 matrices
  - Large rectangular (20x15 * 15x25)
- Special Matrix Content:
  - Matrices with zeros

**6. Mulf Operator (test_mulf.c)**

Category

- Scalar Tensor * Float
- Vector Tensor * Float
- Matrix Tensor * Float
- Tensor * Zero
- Special Scalar Values:
  - Multiplication by zero
  - Very small scalar multiplication
- Higher Dimensional Tensors:
  - 3D tensor scalar multiplication
  - 4D tensor scalar multiplication

**7. Sum Operator (test_sum.c)**

Category

- Sum of a scalar tensor
- Sum of a vector tensor
- Sum of a matrix tensor
- Sum of tensor with negative numbers
- Large Tensor Reductions:
  - Sum of 1,000 elements
  - Sum of 5,000 elements
- Higher Dimensional Tensors:
  - 3D tensor sum
  - 4D tensor sum


### Future Improvements
Some broadcasting functionality is commented out with `TODO` markers, indicating areas for future implementation